### PR TITLE
Add registry key for mouse focus control

### DIFF
--- a/parts/setup-wineprefix.md
+++ b/parts/setup-wineprefix.md
@@ -9,3 +9,5 @@ Creating a new wineprefix configured best for [compatible apps/games](https://gi
   * Type `wine reg add "HKEY_CURRENT_USER\Software\Wine\DllOverrides" /v winhttp /t reg_sz /d native,builtin /f`in the terminal
 * Disable WPF hardware acceleration to prevent graphical glitches with launchers, dnspy
   * Type `wine reg add "HKEY_CURRENT_USER\SOFTWARE\Microsoft\Avalon.Graphics" /v DisableHWAcceleration /t REG_DWORD /d 1 /f` in the terminal
+* Prevent possible mouse focus issues when alt+tab out of window
+  * Type `wine reg ADD 'HKEY_CURRENT_USER\Software\Wine\X11 Driver' /v UseTakeFocus /d 'N' /f` in the terminal


### PR DESCRIPTION
I've noticed with AI Syoujo and Koikatsu Sunshine, leaving the game window and coming back in breaks mouse control with wine (at least version 6.16 at time of writing). Adding this registry key seems to fix this issue.

Using wine's virtual desktop can also fix the issue, but this is a nicer fix.