### PR TITLE
Added -q flag, so dotnet installs without gui

### DIFF
--- a/parts/setup-wineprefix.md
+++ b/parts/setup-wineprefix.md
@@ -3,7 +3,9 @@ Creating a new wineprefix configured best for [compatible apps/games](https://gi
 **Steps:**
 * Create, set up the wineprefix by running the following in terminal:
   * `export WINEPREFIX="~/.wine_custom"` (path to your new wineprefix, change as needed)
-  * `winetricks corefonts dxvk ole32 dotnet35 dotnet472`    (skip `dxvk` if using MacOS)
+  * `winetricks corefonts dxvk ole32`    (skip `dxvk` if using MacOS)
+  * `winetricks -q dotnet35`
+  * `winetricks -q dotnet472`
   * If asked to install mono, gecko, click no
 * Allow the native winhttp wrapper be loaded
   * Type `wine reg add "HKEY_CURRENT_USER\Software\Wine\DllOverrides" /v winhttp /t reg_sz /d native,builtin /f`in the terminal


### PR DESCRIPTION
On my Fedora 36 installation _dotnet_ (both 35 and 472) would fail to install without _-q_ flag. Maybe add it just in case? Plus user wouldn't have to click anything else to install _dotnet_, just enter the command and it installs itself.
Not sure if separating those commands is needed though.